### PR TITLE
[scitedotai/scite#1893] Remove report link from itemPane

### DIFF
--- a/content/scite.ts
+++ b/content/scite.ts
@@ -240,7 +240,6 @@ class CScite { // tslint:disable-line:variable-name
         responseType: 'json',
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       })
-      Zotero.logError(res)
       const doiTallies = res?.response ? res.response.tallies : {}
       for (const doi of Object.keys(doiTallies)) {
         debug(`scite bulk DOI refresh: ${doi}`)

--- a/locale/en-US/zotero-scite.properties
+++ b/locale/en-US/zotero-scite.properties
@@ -1,2 +1,2 @@
-itemPane.summary = <p><b>Supporting Tallies</b>: {{supporting}}</p><p><b>Disputing Tallies</b>: {{contradicting}}</p><p><b>Mentioning Tallies</b>: {{mentioning}}</p><p><b>View scite report</b>: <a href="{{reportLink}}">{{reportLink}}</a></p>
+itemPane.summary = <p><b>Supporting Tallies</b>: {{supporting}}</p><p><b>Disputing Tallies</b>: {{contradicting}}</p><p><b>Mentioning Tallies</b>: {{mentioning}}</p>
 itemPane.noTallies = No <b>scite</b> tallies


### PR DESCRIPTION
## Changelog

The report link from the item pane is buggy when opened (it opens within Zotero, not a separate browser, and has rendering issues / needs a restart)... so just remove.

(You can still go to a report by right clicking the item and clicking the option)