### PR TITLE
[noref] Use DOMParser and XMLSerializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ To install a plugin in Zotero, download its .xpi file to your computer. Then, in
 
 NOTE: You only need to download once; it will auto update afterwards!
 
+### [1.0.7](https://github.com/scitedotai/scite-zotero-plugin/releases/tag/v1.0.7)
+
+- Use DOMParser and XMLSerializer.
+
 ### [1.0.6](https://github.com/scitedotai/scite-zotero-plugin/releases/tag/v1.0.6)
 
 - Rename disputed to contrasted, and change the color of the icon from orange to blue.

--- a/content/itemPane.ts
+++ b/content/itemPane.ts
@@ -1,9 +1,7 @@
 declare const Zotero: IZotero
-declare const Components: any
 declare const ZoteroItemPane: any
 
 import { patch as $patch$ } from './monkey-patch'
-import { debug } from './debug'
 
 const xul = 'http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul'
 

--- a/content/itemPane.ts
+++ b/content/itemPane.ts
@@ -13,8 +13,8 @@ const SciteItemPane = new class { // tslint:disable-line:variable-name
   private observer: number = null
 
   private dom = {
-    parser: Components.classes['@mozilla.org/xmlextras/domparser;1'].createInstance(Components.interfaces.nsIDOMParser),
-    serializer: Components.classes['@mozilla.org/xmlextras/xmlserializer;1'].createInstance(Components.interfaces.nsIDOMSerializer),
+    parser: new DOMParser,
+    serializer: new XMLSerializer,
   }
 
   public async notify(action, type, ids) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
       "preserveConstEnums": false,
       "sourceMap": false,
       "downlevelIteration": true,
-      "lib": [ "es2017", "dom" ],
+      "lib": [ "es2017", "dom", "dom.iterable" ],
       "typeRoots": [
         "./typings",
         "./node_modules/@types"


### PR DESCRIPTION
Fixes: https://github.com/scitedotai/scite-zotero-plugin/issues/16

Previously the DOMPaser and XMLSerializer we used were:

```
    parser: Components.classes['@mozilla.org/xmlextras/domparser;1'].createInstance(Components.interfaces.nsIDOMParser),
    serializer: Components.classes['@mozilla.org/xmlextras/xmlserializer;1'].createInstance(Components.interfaces.nsIDOMSerializer),
```

Instead just use:

```
parser: DOMParser,
serializer: XMLSerializer
```

These are used when rendering the scite tally info in the panel on the right, e.g. here:

<img width="416" alt="Screen Shot 2021-03-31 at 9 56 06 AM" src="https://user-images.githubusercontent.com/14264791/113165154-55646000-9207-11eb-85ec-f9cba7aadcdc.png">

For some reason if we use the parser / serializer that we originally had, zotero throws an exception if trying to use the `DOMParser()` elsewhere.

But using the `DOMParser` instead allows you to use both types of parsers when running javascript.

I guess this might be some internal zotero issue, but this fixes it for now:

- [x] scite plugin behavior is unchanged
- [x] I can go into `Run Javascript` and run this which works
```
var parser = new DOMParser();
var resptext = "<p>Test</p><div>divNext</div>";
var html = parser.parseFromString(resptext, 'text/html');
```
- [x] I can go into `Run Javascript` and run this which works
```
var parser = Components.classes["@mozilla.org/xmlextras/domparser;1"]
            .createInstance(Components.interfaces.nsIDOMParser);
var resptext = "<p>Test</p><div>divNext</div>";
var html = parser.parseFromString(resptext, 'text/html');
```