### PR TITLE
Refresh rows after API calls resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ To install a plugin in Zotero, download its .xpi file to your computer. Then, in
 
 NOTE: You only need to download once; it will auto update afterwards!
 
+### [1.11.0](https://github.com/scitedotai/scite-zotero-plugin/releases/tag/v1.11.0)
+
+- Fix bug in beta build where the tally information in each row was not refreshed after the initial load from the API.
+
 ### [1.10.0](https://github.com/scitedotai/scite-zotero-plugin/releases/tag/v1.10.0)
 
 - Add backwards-compatible support for upcoming Zotero release. This specifically makes the plugin work with the build `Zotero-5.0.97-beta.43+c5d89f6d0` but should generally support the new HTML based structure (in addition to the XUL version for any users who do not upgrade).


### PR DESCRIPTION
Fixes: https://github.com/scitedotai/scite-zotero-plugin/issues/27

- Use `ZoteroPane.itemsView.refreshAndMaintainSelection()` after the API calls finish to re-render the rows so the loading icon automatically goes away and the tally info shows
- Fix bug where the code to refresh tallies in chunks of 500 would return without properly awaiting

Tested on both stable and beta builds