### PR TITLE
Fix bug where column sort breaks in zotero 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ To install a plugin in Zotero, download its .xpi file to your computer. Then, in
 
 NOTE: You only need to download once; it will auto update afterwards!
 
+### [1.11.3](https://github.com/scitedotai/scite-zotero-plugin/releases/tag/v1.11.3)
+
+- Fix bug where column sorting on scite specific columns did not work in Zotero 6.
+
 ### [1.11.2](https://github.com/scitedotai/scite-zotero-plugin/releases/tag/v1.11.2)
 
 - Upgrade `zotero-plugin` dependency with support for Zotero 6 (backwards compatible), and use eslint instead of tslint.


### PR DESCRIPTION
Fixes https://github.com/scitedotai/scite-zotero-plugin/issues/35

- Previously the value passed into that function was e.g. just `supporting`, and we would construct the full column key `zotero-items-column-{field}` to check if it existed
- But in Zotero 6, it gets passed in with the full name (probably they use `dataKey` instead of `id` to pass it in), which causes this to fail and break when sorting
- Make this more robust by handling both cases better.
- I verified this works in Zotero 5 and 6.