### PR TITLE
Re-enable scite plugin, and fix getField function so it stops passing bad data to DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,18 @@ NOTES: (temporary workaround due to its implementation)
 - If you make changes, do NOT run `npm version` before your pull request gets merged
 - First merge in the pull request
 - Then from `master`, pull locally
-- While on `master`, run `npm version <version>`
+- While on `master`, run `npm version <version>`, e.g. `npm version 1.2.3`
 - This will create a new tag, commit, and push and that will auto-trigger the CI to release it
 
 If you run `npm version` before the PR gets merged, then the tagged commit will have a hash different from the commit hash in circle after it gets merged (github will always create a new commit for the merge)
 
-TL;DR Let me do it ;)
+## How to disable the plugin
+
+In the event of a bug that gets released, the easiest way to disable the scite plugin is to:
+
+- Go to `/content/config.js` and set the `PLUGIN_ENABLED` flag to `false`
+- Merge this into `master`
+- Then, from `master` locally, run `npm version <new_version>` to release a new version, e.g. if it was on `1.2.3`, run `npm version 1.2.4`.
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ To install a plugin in Zotero, download its .xpi file to your computer. Then, in
 
 NOTE: You only need to download once; it will auto update afterwards!
 
+### [1.11.5](https://github.com/scitedotai/scite-zotero-plugin/releases/tag/v1.11.5)
+
+- Re-enables scite plugin and fixes bug in patched `getField` function which was raising an exception for `int` fields being passed in, causing non-scite specific columns to go into the exception handler, which swallowed the exception and returned 0. This exception handler now only happens on scite specific columns as intended, and the handling of `field` is more robust to prevent the identified sources of exceptions.
+
 ### [1.11.4](https://github.com/scitedotai/scite-zotero-plugin/releases/tag/v1.11.4)
 
 - Disables the scite plugin from doing anything when it loads -- due to intermittent bug found in Zotero 6 upgrade.

--- a/content/config.js
+++ b/content/config.js
@@ -1,1 +1,1 @@
-export const PLUGIN_ENABLED = false;
+export const PLUGIN_ENABLED = true;


### PR DESCRIPTION
This is kind of complicated, but it addresses the bug reported and discussed in https://github.com/scitedotai/scite-zotero-plugin/issues/38

I think what's happening is that the `getField()` function [we patched](https://github.com/scitedotai/scite-zotero-plugin/blob/495e2e62d8e2f9da4b4704f7fbba21eb8a80115a/content/scite.ts#L229-L244) was raising an exception on:
- This line of code, which needs a `[0]` after the `slice(-1)` -- https://github.com/scitedotai/scite-zotero-plugin/blob/495e2e62d8e2f9da4b4704f7fbba21eb8a80115a/content/scite.ts#L229
- And again on the above line of code if the value of `field` that was passed in was an `integer` instead of a `string` -- I believe this is the case because I saw a lot of `field.includes is not a function` messages in the exceptions in the console.

If either of those two error scenarios happen, it goes into the `catch` block and then swallows the exception and does a `return 0`. Perhaps that was happening on non-scite specific columns, e.g. it might have happened on `title` or `DOI`, if it raised an exception due to the `slice` bug I mentioned above.

The thing is, that catch block _is only supposed to happen for scite specific columns_ for that exact reason. We don't want to tell Zotero the value of some column out of our control is `0`.


## Changelog
- Re-enable the scite plugin again
-  Move the `try / catch` block to be specific to the scite case. This means that if an exception happens earlier for any reason, it'll just break a little more gracefully (better than overwriting fields).
- Make the check for whether the field is within the scite column list a bit more robust by:
    - Ensuring it is a string; if not, just do the original function. All the scite columns are strings.
    - Eliminate the two sources of exceptions identified above

## Verification

I [used this `xpi` file](https://github.com/scitedotai/scite-zotero-plugin/files/8321265/zotero-scite-6-debug-version.xpi.zip) locally to verify this in the following ways:

- Starting with Zotero 5, with the above XPI file, I re-synced my DB from scratch and verified it all worked:

<img width="1591" alt="Screen Shot 2022-03-21 at 11 48 41 PM" src="https://user-images.githubusercontent.com/14264791/159411120-b3526f6d-51c7-494d-a73b-bc0775860c8b.png">

- Then, I upgraded to Zotero 6 with the plugin enabled, and verified everything worked.
- Then, I did a fresh installation of Zotero 6 with the plugin enabled, and then re-synced the same library again, and verified everything worked:
<img width="1913" alt="Screen Shot 2022-03-21 at 11 50 15 PM" src="https://user-images.githubusercontent.com/14264791/159411166-5c4cec96-36e0-46c0-ad00-9bd20de83762.png">


## Misc

I think earlier this morning when this worked for me, I might have gotten lucky with the library I tested with, since it was a smaller one with about 6 test publications.

//cc @dstillman

